### PR TITLE
Replace percent formatting to be done using DecimalFormat

### DIFF
--- a/Gradle_Build_Tool_Plugin_Development/exercise3/README.md
+++ b/Gradle_Build_Tool_Plugin_Development/exercise3/README.md
@@ -91,7 +91,11 @@ private fun parseCoveragePercentage(reportFile: File, parser: XmlParser): Float?
 
             val total : Float = missed + covered
             val percent : Float = covered / total
-            return String.format("%.2f", percent).toFloat()
+
+            // Use formatter to round to the floor.
+            val formatter = DecimalFormat("#.##")
+            formatter.roundingMode = RoundingMode.FLOOR
+            return formatter.format(percent).toFloat()
         }
     }
 

--- a/Gradle_Build_Tool_Plugin_Development/exercise3/solution/plugin/src/main/kotlin/com/gradlelab/CoverageLockInTask.kt
+++ b/Gradle_Build_Tool_Plugin_Development/exercise3/solution/plugin/src/main/kotlin/com/gradlelab/CoverageLockInTask.kt
@@ -10,6 +10,8 @@ import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import java.io.File
+import java.math.RoundingMode
+import java.text.DecimalFormat
 
 abstract class CoverageLockInTask : DefaultTask() {
 
@@ -72,7 +74,11 @@ abstract class CoverageLockInTask : DefaultTask() {
 
                 val total : Float = missed + covered
                 val percent : Float = covered / total
-                return String.format("%.2f", percent).toFloat()
+
+                // Use formatter to round to the floor.
+                val formatter = DecimalFormat("#.##")
+                formatter.roundingMode = RoundingMode.FLOOR
+                return formatter.format(percent).toFloat()
             }
         }
 


### PR DESCRIPTION
Occasionally the String.format approach of formatting the percent to two decimal places rounds up when the correct solution would be to round down. This PR replaces the existing approach with DecimalFormat to ensure we round to the floor instead.

Also updated the code snipped in the README.md so that documentation reflects the code change as well.